### PR TITLE
hash out allow values

### DIFF
--- a/lets-encrypt/activate-ssl.sh
+++ b/lets-encrypt/activate-ssl.sh
@@ -203,8 +203,8 @@ server {
     location ~* \.php$ {
         location ~ \wp-login.php$ {
                     allow $GATEWAY/24;
-		            allow $ADDRESS;
-		            allow $WAN4IP;
+		    #allow $ADDRESS;
+		    #allow $WAN4IP;
                     deny all;
                     include fastcgi.conf;
                     fastcgi_intercept_errors on;

--- a/wordpress_install.sh
+++ b/wordpress_install.sh
@@ -506,8 +506,8 @@ server {
     location ~* \.php$ {
         location ~ \wp-login.php$ {
                     allow $GATEWAY/24;
-		    allow $ADDRESS;
-		    allow $WAN4IP;
+		    #allow $ADDRESS;
+		    #allow $WAN4IP;
                     deny all;
                     include fastcgi.conf;
                     fastcgi_intercept_errors on;
@@ -585,8 +585,8 @@ server {
     location ~* \.php$ {
         location ~ \wp-login.php$ {
                     allow $GATEWAY/24;
-		    allow $ADDRESS;
-		    allow $WAN4IP;
+		    #allow $ADDRESS;
+		    #allow $WAN4IP;
                     deny all;
                     include fastcgi.conf;
                     fastcgi_intercept_errors on;


### PR DESCRIPTION
if WAN IP isn't set nginx will fail to restart.

Make it optional instead.